### PR TITLE
generate_early performance improvements

### DIFF
--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -7,7 +7,7 @@ from BaseClasses import MultiWorld
 from worlds.generic.Rules import set_rule
 
 
-def add_piece(previous_solution, piece, nx, ny):
+def add_piece(previous_solution, piece, nx, ny, added_piece_count):
     pieces_to_merge = set()
     if piece <= nx * (ny - 1):
         pieces_to_merge.add(piece + nx)
@@ -28,9 +28,9 @@ def add_piece(previous_solution, piece, nx, ny):
             new_solution.append(group)
     
     new_solution.append(merged_group)
-    return new_solution, sum(len(group) for group in new_solution) - len(new_solution)
+    return new_solution, added_piece_count + 1 - len(new_solution)
 
-def remove_piece(previous_solution, piece, nx, ny):
+def remove_piece(previous_solution, piece, nx, ny, added_piece_count):
     # Find the group in previous_solution that piece is in
     group_to_remove = None
     for group in previous_solution:
@@ -39,7 +39,7 @@ def remove_piece(previous_solution, piece, nx, ny):
             break
     
     if not group_to_remove:
-        return previous_solution, sum(len(group) for group in previous_solution) - len(previous_solution)  # Piece not found in any group
+        return previous_solution, added_piece_count - len(previous_solution)  # Piece not found in any group
     
     # Remove piece from that group and then remove that group in total (but keep it in memory)
     group_to_remove.remove(piece)
@@ -47,9 +47,9 @@ def remove_piece(previous_solution, piece, nx, ny):
     
     # Re-add the remaining pieces in the removed group
     partial_solution = []
-    for remaining_piece in group_to_remove:
-        partial_solution, _ = add_piece(partial_solution, remaining_piece, nx, ny)
+    for partial_piece_count, remaining_piece in enumerate(group_to_remove):
+        partial_solution, _ = add_piece(partial_solution, remaining_piece, nx, ny, partial_piece_count)
     
     new_solution = previous_solution + partial_solution
     
-    return new_solution, sum(len(group) for group in new_solution) - len(new_solution)
+    return new_solution, added_piece_count - 1 - len(new_solution)

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -22,7 +22,7 @@ def add_piece(previous_solution, piece, nx, ny):
     new_solution = []
     
     for group in previous_solution:
-        if pieces_to_merge & group:
+        if not pieces_to_merge.isdisjoint(group):
             merged_group.update(group)
         else:
             new_solution.append(group)

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -22,12 +22,12 @@ def add_piece(previous_solution, piece, nx, ny):
     new_solution = []
     
     for group in previous_solution:
-        if pieces_to_merge & set(group):
+        if pieces_to_merge & group:
             merged_group.update(group)
         else:
             new_solution.append(group)
     
-    new_solution.append(list(merged_group))
+    new_solution.append(merged_group)
     return new_solution, sum(len(group) for group in new_solution) - len(new_solution)
 
 def remove_piece(previous_solution, piece, nx, ny):

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -30,6 +30,29 @@ def add_piece(previous_solution, piece, nx, ny, added_piece_count):
     new_solution.append(merged_group)
     return new_solution, added_piece_count + 1 - len(new_solution)
 
+
+def get_merges_from_adding_piece(previous_solution, piece, nx, ny, added_piece_count):
+    """add_piece, but without creating a new solution for better performance when a new solution is not needed."""
+    pieces_to_merge = set()
+    if piece <= nx * (ny - 1):
+        pieces_to_merge.add(piece + nx)
+    if piece > nx:
+        pieces_to_merge.add(piece - nx)
+    if piece % nx != 1:
+        pieces_to_merge.add(piece - 1)
+    if piece % nx != 0:
+        pieces_to_merge.add(piece + 1)
+
+    # Every group that does not intersect with `pieces_to_merge` will be a group in the new solution.
+    # Every group that does intersect with `pieces_to_merge` will merge with `pieces_to_merge` to become a single group
+    # in the new solution.
+    # Iterating `previous_solution` and counting the number of groups is a hot loop. `sum` and `map` allow for both to
+    # be performed in optimised C code. Only binding `pieces_to_merge.isdisjoint` once also helps a bit with
+    # performance.
+    new_solution_length = 1 + sum(map(pieces_to_merge.isdisjoint, previous_solution))
+    return added_piece_count + 1 - new_solution_length
+
+
 def remove_piece(previous_solution, piece, nx, ny, added_piece_count):
     # Find the group in previous_solution that piece is in
     group_to_remove = None

--- a/worlds/jigsaw/__init__.py
+++ b/worlds/jigsaw/__init__.py
@@ -138,6 +138,7 @@ class JigsawWorld(World):
         
         merges = 0
         clusters = []
+        added_piece_count = 0
         
         self.precollected_pieces = []
         self.itempool_pieces = []
@@ -158,7 +159,7 @@ class JigsawWorld(World):
                     elif self.options.piece_order == PieceOrder.option_every_piece_fits:
                         for i in range(len(pieces)):
                             p = pieces[i]
-                            c, m = add_piece(clusters, p, self.nx, self.ny)
+                            c, m = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
                             if first_piece or m > merges:
                                 pieces.remove(p)
                                 break
@@ -170,7 +171,7 @@ class JigsawWorld(World):
                         best_result = 5
                         for i in range(len(pieces)):
                             p = pieces[i]
-                            c, m = add_piece(clusters, p, self.nx, self.ny)
+                            c, m = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
                             if first_piece or m - merges <= best_result_ever:
                                 best_piece = p
                                 best_result = 0
@@ -192,7 +193,8 @@ class JigsawWorld(World):
                 else:
                     self.precollected_pieces.append(p)  # if no merges left, add piece to start_inventory
                     
-                clusters, merges = add_piece(clusters, p, self.nx, self.ny)  # update number of merges left
+                clusters, merges = add_piece(clusters, p, self.nx, self.ny, added_piece_count)  # update number of merges left
+                added_piece_count += 1
                 
                 first_piece = False
                     
@@ -200,18 +202,21 @@ class JigsawWorld(World):
         self.actual_possible_merges = [0]
         merges = 0
         clusters = []
+        added_piece_count = 0
         
         for p in self.precollected_pieces:
-            clusters, merges = add_piece(clusters, p, self.nx, self.ny)
+            clusters, merges = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
             self.possible_merges.append(merges - self.options.number_of_checks_out_of_logic.value) 
             self.actual_possible_merges.append(merges)
+            added_piece_count += 1
         for c, p in enumerate(self.itempool_pieces):
-            clusters, merges = add_piece(clusters, p, self.nx, self.ny)
+            clusters, merges = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
             if len(self.itempool_pieces) - c < 10:
                 self.possible_merges.append(merges)   
             else:
                 self.possible_merges.append(merges - self.options.number_of_checks_out_of_logic.value)   
             self.actual_possible_merges.append(merges)
+            added_piece_count += 1
         
         self.pieces_needed_per_merge = [0]
         for i in range(1, self.npieces):

--- a/worlds/jigsaw/__init__.py
+++ b/worlds/jigsaw/__init__.py
@@ -9,7 +9,7 @@ from .Items import JigsawItem, item_table, item_groups
 from .Locations import JigsawLocation, location_table
 
 from .Options import JigsawOptions, OrientationOfImage, PieceOrder, PieceTypeOrder, StrictnessPieceOrder
-from .Rules import add_piece
+from .Rules import add_piece, get_merges_from_adding_piece
 
 
 class JigsawWeb(WebWorld):
@@ -159,7 +159,7 @@ class JigsawWorld(World):
                     elif self.options.piece_order == PieceOrder.option_every_piece_fits:
                         for i in range(len(pieces)):
                             p = pieces[i]
-                            c, m = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
+                            m = get_merges_from_adding_piece(clusters, p, self.nx, self.ny, added_piece_count)
                             if first_piece or m > merges:
                                 pieces.remove(p)
                                 break
@@ -171,7 +171,7 @@ class JigsawWorld(World):
                         best_result = 5
                         for i in range(len(pieces)):
                             p = pieces[i]
-                            c, m = add_piece(clusters, p, self.nx, self.ny, added_piece_count)
+                            m = get_merges_from_adding_piece(clusters, p, self.nx, self.ny, added_piece_count)
                             if first_piece or m - merges <= best_result_ever:
                                 best_piece = p
                                 best_result = 0


### PR DESCRIPTION
## What is this fixing or adding?

Improves the performance of `generate_early()`, particularly for least merges possible order and to a lesser extent every piece fits order. Random order is close to unaffected by these changes.

### [Keep clusters as sets instead of converting to lists and back again](https://github.com/spineraks-org/ArchipelagoJigsaw/commit/ad160a01761df8529cb58cd95e4ae95b33aeb952)

This takes a 1000 piece 100% strictness least merges order puzzle's generate_early from 15s to 10s for me, and produces identical output with the same seed.

### [Use set.isdisjoint instead of creating intersection sets](https://github.com/spineraks-org/ArchipelagoJigsaw/commit/11674e599825ce782e894ef81321a700a853c132)

When only the knowledge of whether two sets intersect is needed and not what the actual intersection is, negating the result of set.isdisjoint can be used to more efficiently find whether two sets intersect.

This takes a 1000 piece 100% strictness least merges order puzzle's generate_early from 10s to 7.5s for me, and produces identical output with the same seed.

### [Track the number of added pieces instead of calculating it each time](https://github.com/spineraks-org/ArchipelagoJigsaw/commit/b1e9dd29400bc92b942eca5bfaac41053add5f5e)

The number of pieces in the current clusters can be tracked and incremented every time a piece is added.

This avoids recalculating the more costly operation of counting the total number of pieces in the current clusters each time.

This takes a 1000 piece 100% strictness least merges order puzzle's generate_early from 7.5s to 5s for me, and produces identical output with the same seed.

The unused `remove_piece()` function has been modified, but has not been tested.

### [Skip creating a new solution when only the number of merges is needed](https://github.com/spineraks-org/ArchipelagoJigsaw/pull/2/commits/1948ed03999967b83fc542e6978ad333de72314f)

This removes some of the work that add_piece was doing that is not necessary for testing if a piece is suitable to create a new solution given a specific piece_order.

This change alone reduces takes a 1000 piece 100% strictness least merges order puzzle's generate_early from 5s to 4.4s for me, and produces identical output with the same seed.

However, the iteration and summation can now be performed in optimised C code using `sum` and `map`, further reducing from 4.4s to 2.8s.

## How was this tested?

Generations with a fixed seed with a 1000 piece random order yaml, a 1000 piece least merges order yaml, and a 1000 piece every piece fits order yaml produced the same result before and after, but with better `generate_early()` performance.