### PR TITLE
Reimplement adding pieces and counting merges to speed up generate_early

### DIFF
--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -92,6 +92,7 @@ class PuzzleBoard:
         The behavior of attempting to add a piece which is already present in the board is undefined.
         """
         board = self.board
+        assert board[piece_index] is None, "Attempted to add a piece already present in the board"
 
         # Get all adjacent cluster IDs.
         # Use incorrect typing to begin with because it is more efficient to remove `None` this way.
@@ -158,6 +159,7 @@ class PuzzleBoard:
         """
         # Get all adjacent cluster IDs.
         board = self.board
+        assert board[piece_idx] is None, "Attempted to get the merges for adding a piece already present in the board"
         found_clusters = {board[connection] for connection in self.adjacent_pieces[piece_idx]}
         # Empty spaces on the board are set to `None`.
         return len(found_clusters) - 1 if None in found_clusters else len(found_clusters)

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -150,7 +150,12 @@ class PuzzleBoard:
                     board[piece_idx] = largest_cluster_id
 
     def get_merges_from_adding_piece(self, piece_idx: int):
-        """Get the number of merges that would be made by adding a piece."""
+        """
+        Get the number of merges that would be made by adding a piece.
+
+        The behavior of attempting to get the number of merges from adding a piece which is already present in the board
+        is undefined.
+        """
         # Get all adjacent cluster IDs.
         board = self.board
         found_clusters = {board[connection] for connection in self.adjacent_pieces[piece_idx]}

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -7,49 +7,167 @@ from BaseClasses import MultiWorld
 from worlds.generic.Rules import set_rule
 
 
-def add_piece(previous_solution, piece, nx, ny):
-    pieces_to_merge = set()
-    if piece <= nx * (ny - 1):
-        pieces_to_merge.add(piece + nx)
-    if piece > nx:
-        pieces_to_merge.add(piece - nx)
-    if piece % nx != 1:
-        pieces_to_merge.add(piece - 1)
-    if piece % nx != 0:
-        pieces_to_merge.add(piece + 1)
-    
-    merged_group = {piece}
-    new_solution = []
-    
-    for group in previous_solution:
-        if pieces_to_merge & set(group):
-            merged_group.update(group)
-        else:
-            new_solution.append(group)
-    
-    new_solution.append(list(merged_group))
-    return new_solution, sum(len(group) for group in new_solution) - len(new_solution)
+class PuzzleBoard:
+    """
+    Puzzle board implementation.
 
-def remove_piece(previous_solution, piece, nx, ny):
-    # Find the group in previous_solution that piece is in
-    group_to_remove = None
-    for group in previous_solution:
-        if piece in group:
-            group_to_remove = group
-            break
-    
-    if not group_to_remove:
-        return previous_solution, sum(len(group) for group in previous_solution) - len(previous_solution)  # Piece not found in any group
-    
-    # Remove piece from that group and then remove that group in total (but keep it in memory)
-    group_to_remove.remove(piece)
-    previous_solution.remove(group_to_remove)
-    
-    # Re-add the remaining pieces in the removed group
-    partial_solution = []
-    for remaining_piece in group_to_remove:
-        partial_solution, _ = add_piece(partial_solution, remaining_piece, nx, ny)
-    
-    new_solution = previous_solution + partial_solution
-    
-    return new_solution, sum(len(group) for group in new_solution) - len(new_solution)
+    Optimized for efficient adding pieces to the board and calculating the number of new merges that would be made when
+    adding a piece.
+
+    The pieces in each group are not tracked because this makes adding pieces more expensive, this makes piece removal
+    more expensive, however, the removal of pieces is not expected to occur often.
+
+    A board stores a group ID value for each piece placed on the board, where `None` indicates an empty space on the
+    board.
+    _0____3_
+    ____4_3_
+    __1_____
+    __1_22__
+
+    Piece placement behaviours:
+    A)
+    A newly placed piece that does not connect to any existing placed pieces is given a new unique group ID.
+    _0____3_
+    ____4_3_
+    __1_____
+    __1_22_5 <--
+
+    B)
+    A newly placed piece that connects to only a single group ID gains the group ID of the connecting piece.
+    _0____3_
+    ____4_33 <--
+    __1_____
+    __1_22_5
+
+    C)
+    When a piece is placed that would connect to multiple existing groups, one way to handle this is to set all the
+    pieces in those groups to the group ID of the largest group.
+    _0____3_     _0____3_
+    ____4_33     ____4_33
+    __1____X <-- __1____3 <--
+    __1_22_5     __1_22_3 <--
+    However, this gets expensive to do as the groups get larger. Instead, a dictionary is used that maps each group ID
+    already on the board to a 'real' group ID:
+    _0____3_     _0____3_
+    ____4_33     ____4_33
+    __1____X <-- __1____3 <--
+    __1_22_5     __1_22_5
+    group_to_real_group[5] = 3
+    real_group_to_groups[3].append(5)
+    This means that other operations that need to check what group a piece is in need to get the group ID as stored on
+    the board, but then look up the real group ID with `real_group_id = group_to_real_group[group_id_from_board]`.
+    """
+    __slots__ = ("width", "board", "adjacent_pieces", "merges_count", "group_to_real_group", "real_group_to_groups",
+                 "_unused_ids")
+
+    # The width of the puzzle board.
+    width: int
+    # The puzzle board itself. A 1D list used to represent a 2D board.
+    board: list[int | None]
+    # A lookup of the adjacent pieces of each piece, used like a dict[int, tuple[int, ...]].
+    adjacent_pieces: tuple[tuple[int, ...], ...]
+    # The count of merged groups of connected pieces.
+    merges_count: int
+    # group ID -> real group ID, used like a dict[int, int]
+    group_to_real_group: list[int]
+    # real group ID -> group IDs mapped to this real group ID
+    real_group_to_groups: dict[int, list[int]]
+
+    # Unused group IDs that newly added pieces can be assigned to if they do not merge into an existing group.
+    _unused_ids: list[int]
+
+    def __init__(self, width: int, height: int):
+        self.width = width
+
+        pieces = range(width * height)
+        self._unused_ids = list(pieces)
+        self.board = [None] * len(pieces)
+
+        # Pre-calculate the pieces that are adjacent to each piece.
+        adjacent_pieces = []
+        for i in pieces:
+            piece_connections = []
+            x = i % width
+            y = i // width
+            if x > 0:
+                piece_connections.append(i - 1)
+            if x < width - 1:
+                piece_connections.append(i + 1)
+            if y > 0:
+                piece_connections.append(i - width)
+            if y < height - 1:
+                piece_connections.append(i + width)
+            adjacent_pieces.append(tuple(piece_connections))
+        self.adjacent_pieces = tuple(adjacent_pieces)
+
+        self.merges_count = 0
+        self.group_to_real_group = [-1] * len(self._unused_ids)
+        self.real_group_to_groups = {}
+
+    def add_piece(self, piece_index: int):
+        """
+        Add a piece to the board.
+
+        The behavior of attempting to add a piece which is already present in the board is undefined.
+        """
+        board = self.board
+
+        # Get all adjacent group IDs.
+        found_groups = {board[connection] for connection in self.adjacent_pieces[piece_index]}
+        # Empty spaces on the board are set to `None`.
+        found_groups.discard(None)
+
+        num_adjacent_groups = len(found_groups)
+        if num_adjacent_groups == 0:
+            # Loose piece, give it a new ID
+            new_id = self._unused_ids.pop()
+            board[piece_index] = new_id
+            self.group_to_real_group[new_id] = new_id
+            self.real_group_to_groups[new_id] = [new_id]
+        elif num_adjacent_groups == 1:
+            # Only one connecting group
+            self.merges_count += 1
+            board[piece_index] = next(iter(found_groups))
+        else:
+            # Multiple connecting groups, determine the real groups.
+            group_to_real_group = self.group_to_real_group
+            real_groups = {group_to_real_group[found_group] for found_group in found_groups}
+            num_real_groups = len(real_groups)
+            self.merges_count += num_real_groups
+            if num_real_groups == 1:
+                board[piece_index] = next(iter(real_groups))
+            else:
+                # Pick the first real group as the new real group.
+                real_groups_iter = iter(real_groups)
+                new_real_group = next(real_groups_iter)
+                board[piece_index] = new_real_group
+
+                # Re-map all groups mapped to the remaining real groups to the new real group.
+                real_group_to_groups = self.real_group_to_groups
+                groups_mapped_to_real_group = real_group_to_groups[new_real_group]
+                for other_real_group in real_groups_iter:
+                    groups = real_group_to_groups[other_real_group]
+                    groups_mapped_to_real_group.extend(groups)
+                    del real_group_to_groups[other_real_group]
+                    for g in groups:
+                        group_to_real_group[g] = new_real_group
+
+    def get_merges_from_adding_piece(self, piece_idx: int):
+        """Get the number of merges that would be made by adding a piece."""
+
+        # Get all adjacent group IDs.
+        board = self.board
+        found_groups = {board[connection] for connection in self.adjacent_pieces[piece_idx]}
+        # Empty spaces on the board are set to `None`.
+        found_groups.discard(None)
+
+        num_found = len(found_groups)
+        if num_found == 0:
+            return 0
+        elif num_found == 1:
+            # Only one connecting group
+            return 1
+        else:
+            # Multiple connecting groups, return the number of real groups.
+            group_to_real_group = self.group_to_real_group
+            return len({group_to_real_group[found_group] for found_group in found_groups})

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -57,11 +57,7 @@ class PuzzleBoard:
     This means that other operations that need to check what group a piece is in need to get the group ID as stored on
     the board, but then look up the real group ID with `real_group_id = group_to_real_group[group_id_from_board]`.
     """
-    __slots__ = ("width", "board", "adjacent_pieces", "merges_count", "group_to_real_group", "real_group_to_groups",
-                 "_unused_ids")
 
-    # The width of the puzzle board.
-    width: int
     # The puzzle board itself. A 1D list used to represent a 2D board.
     board: list[int | None]
     # A lookup of the adjacent pieces of each piece, used like a dict[int, tuple[int, ...]].
@@ -77,10 +73,11 @@ class PuzzleBoard:
     _unused_ids: list[int]
 
     def __init__(self, width: int, height: int):
-        self.width = width
-
         pieces = range(width * height)
-        self._unused_ids = list(pieces)
+        # The maximum number of IDs that could be needed is the maximum number of isolated pieces possible, which is
+        # half the number of spaces on the board when even, or half the number of spaces plus 1 when odd.
+        max_isolated_pieces = len(pieces) // 2 + len(pieces) % 2
+        self._unused_ids = list(range(max_isolated_pieces))
         self.board = [None] * len(pieces)
 
         # Pre-calculate the pieces that are adjacent to each piece.
@@ -119,7 +116,7 @@ class PuzzleBoard:
 
         num_adjacent_groups = len(found_groups)
         if num_adjacent_groups == 0:
-            # Loose piece, give it a new ID
+            # Isolated piece, give it a new ID
             new_id = self._unused_ids.pop()
             board[piece_index] = new_id
             self.group_to_real_group[new_id] = new_id

--- a/worlds/jigsaw/Rules.py
+++ b/worlds/jigsaw/Rules.py
@@ -156,3 +156,34 @@ class PuzzleBoard:
         found_clusters = {board[connection] for connection in self.adjacent_pieces[piece_idx]}
         # Empty spaces on the board are set to `None`.
         return len(found_clusters) - 1 if None in found_clusters else len(found_clusters)
+
+    def remove_piece(self, piece_idx: int):
+        """
+        Remove a piece from the board.
+
+        This is more expensive than adding pieces and is more expensive the larger the group that the removed piece is
+        in.
+        """
+        board = self.board
+        cluster_id = board[piece_idx]
+        assert cluster_id is not None, "Attempted to remove a piece that is not present in the board"
+        # Remove the cluster this piece is in.
+        pieces_in_cluster = self.clusters.pop(cluster_id)
+        # The cluster ID is now unused, so give it back to the board.
+        self._unused_ids.append(cluster_id)
+
+        # Clear the space on the board where the cluster was
+        for i in pieces_in_cluster:
+            board[i] = None
+
+        # Remove the piece that has been removed from the board.
+        pieces_in_cluster.remove(piece_idx)
+
+        # Reduce the total merges by the merges of the real cluster.
+        # Note that `piece_idx` has already been removed from `pieces_in_cluster`.
+        self.merges_count -= len(pieces_in_cluster)
+
+        # Add all the pieces back on, besides the removed piece.
+        add_piece = self.add_piece
+        for i in pieces_in_cluster:
+            add_piece(i)


### PR DESCRIPTION
## What is this fixing or adding?

Speeds up generate_early by reimplementing the puzzle data structure into a structure that is fast to add pieces to and fast to check for how many merges would be made if a piece was added.

This change has a particularly large impact on least merges possible order and to a lesser extent every piece fits order. Random order is affected the least.

The new implementation is backed by a list, so is zero-indexed, whereas the original code was one-indexed. The original code that adds pieces to the puzzle, and counts how many merges would be made by adding a piece, now has to subtract 1 when calling the new code.

This supersedes #2 because this is much more peformant.

The ability to remove pieces from a board is unused, but has been implemented due to there being an existing implementation to remove pieces from the original puzzle data structure.

## How was this tested?
Generations with a fixed seed with a 1000 piece random order yaml, a 1000 piece least merges order yaml, and a 1000 piece every piece fits order yaml produced the same result before and after, but with better generate_early() performance. The function, that prints how long `generate_early` took, was modified to always print the duration.

`python -O .\Generate.py --skip_output --seed 1`:
Example before:
```
Took 0.5239 seconds in JigsawWorld.generate_early for player 1, named EveryPieceFits.
Took 14.8665 seconds in JigsawWorld.generate_early for player 2, named LeastMerges.
Took 0.0839 seconds in JigsawWorld.generate_early for player 3, named RandomOrder.

Creating MultiWorld.
Creating Items.
Calculating Access Rules.
Running Item Plando.
Running Pre Main Fill.
Filling the multiworld with 2994 items.
Current fill step (Progression) at 1000/2641 items placed.
Current fill step (Progression) at 2000/2641 items placed.
Current fill step (Progression) at 2641/2641 items placed.
Skipping multiworld progression balancing.
Done. Skipped output/spoiler generation. Total Time: 24.232174199998553
```

Example after:
```
Took 0.0567 seconds in JigsawWorld.generate_early for player 1, named EveryPieceFits.
Took 0.1119 seconds in JigsawWorld.generate_early for player 2, named LeastMerges.
Took 0.0246 seconds in JigsawWorld.generate_early for player 3, named RandomOrder.

Creating MultiWorld.
Creating Items.
Calculating Access Rules.
Running Item Plando.
Running Pre Main Fill.
Filling the multiworld with 2994 items.
Current fill step (Progression) at 1000/2641 items placed.
Current fill step (Progression) at 2000/2641 items placed.
Current fill step (Progression) at 2641/2641 items placed.
Skipping multiworld progression balancing.
Done. Skipped output/spoiler generation. Total Time: 8.896331800002372
```
[Players.zip](https://github.com/user-attachments/files/19612201/Players.zip)
